### PR TITLE
Add missing HAVE_UNSIGNED_ cmake vars.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,8 @@ if(UNIX)
     else()
         set( UNSIGNED_CHAR  1 )
         set( UNSIGNED_SHORT 2 )
+        set( HAVE_UNSIGNED_CHAR  1 )
+        set( HAVE_UNSIGNED_SHORT 1 )
     endif()
 
   # Check for compiler features


### PR DESCRIPTION
From cmake `CHECK_TYPE_SIZE` documentation:

```
check if the type exists and determine its size. On return, HAVE_${VARIABLE} holds the existence of the type, and ${VARIABLE} holds one of the following:
<size> = type has non-zero size <size>
"0"    = type has arch-dependent size (see below)
""     = type does not exist
```

HAVE_${VARIABLE} was not being set on emscripten so unsigned char and unsigned short was not used.